### PR TITLE
Es 6.8.7

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y trivy
           # GitHub Action doesn't support docker experimental features
-          # docker builder build --platform linux/amd64,linux/arm64,linux/arm/v7 -t saidsef/elasticsearch:latest .
-          docker build -t saidsef/elasticsearch:latest .
-          trivy --no-progress --exit-code 1 --severity HIGH,CRITICAL saidsef/elasticsearch:latest || true
+          # docker builder build --platform linux/amd64,linux/arm64,linux/arm/v7 -t saidsef/elasticsearch:${GITHUB_REF##*/} .
+          docker build -t saidsef/elasticsearch:${GITHUB_REF##*/} .
+          trivy --no-progress --exit-code 1 --severity HIGH,CRITICAL saidsef/elasticsearch:${GITHUB_REF##*/} || true
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker push saidsef/elasticsearch:${GITHUB_REF##*/}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,15 @@
-name: Docker Image CI
-on: [push, pull_request]
+name: ES Docker Image CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '0 9 * * *'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,4 +24,5 @@ jobs:
           sudo apt-get install -y trivy
           # GitHub Action doesn't support docker experimental features
           # docker builder build --platform linux/amd64,linux/arm64,linux/arm/v7 -t saidsef/elasticsearch:latest .
+          docker build -t saidsef/elasticsearch:latest .
           trivy --no-progress --exit-code 1 --severity HIGH,CRITICAL saidsef/elasticsearch:latest || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM elasticsearch:6.8.7
 
 LABEL maintainer="Said Sef <saidsef@gmail.com> (saidsef.co.uk)"
 
-ENV version 6.8.7
 ENV cluster.name=spot
 ENV node.name=ec2
 ENV ES_JAVA_OPTS="-Xms750m -Xmx1g -XX:CMSInitiatingOccupancyFraction=75"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM elasticsearch:6.8.6
+FROM elasticsearch:6.8.7
 
 LABEL maintainer="Said Sef <saidsef@gmail.com> (saidsef.co.uk)"
 
-ENV version 6.8.6
+ENV version 6.8.7
 ENV cluster.name=spot
 ENV node.name=ec2
 ENV ES_JAVA_OPTS="-Xms750m -Xmx1g -XX:CMSInitiatingOccupancyFraction=75"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN cd /usr/share/elasticsearch \
     && bin/elasticsearch-plugin install -b mapper-annotated-text \
     && bin/elasticsearch-plugin install -b mapper-murmur3 \
     && bin/elasticsearch-plugin install -b mapper-size \
-    && bin/elasticsearch-plugin install -b repository-s3 \
-    && bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/${version}.0/prometheus-exporter-${version}.0.zip
+    && bin/elasticsearch-plugin install -b repository-s3
 
 USER elasticsearch

--- a/README.md
+++ b/README.md
@@ -16,4 +16,3 @@ This will run Elasticsearch in a single node via `env` variable baked into the c
 - ingest-attachment
 - analysis-icu
 - analysis-phonetic
-- prometheus-exporter

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -16,14 +16,15 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9200"
-        prometheus.io/path: "_prometheus/metrics"
+        prometheus.io/port: "9114"
+        prometheus.io/path: "/metrics"
       labels:
         name: elasticsearch
         app: elasticsearch
     spec:
       # hostNetwork: true
       hostNetwork: true
+      shareProcessNamespace: true
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -42,6 +43,13 @@ spec:
             - name: elasticsearch-storage
               mountPath: /usr/share/elasticsearch/data
       containers:
+        - image: justwatch/elasticsearch_exporter:1.1.0
+          name: prometheus
+          command: ["--es.uri=http://localhost:9200", "--es.snapshots=true"]
+          ports:
+            - protocol: TCP
+              containerPort: 9114
+              name: prometheus
         - image: saidsef/elasticsearch
           name: elasticsearch
           ports:

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -8,6 +8,7 @@ metadata:
     app: elasticsearch
 spec:
   serviceName: "elasticsearch"
+  podManagementPolicy: "Parallel"
   replicas: 1
   selector:
     matchLabels:
@@ -23,8 +24,8 @@ spec:
         app: elasticsearch
     spec:
       # hostNetwork: true
-      hostNetwork: true
       shareProcessNamespace: true
+      terminationGracePeriodSeconds: 60
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -43,13 +44,6 @@ spec:
             - name: elasticsearch-storage
               mountPath: /usr/share/elasticsearch/data
       containers:
-        - image: justwatch/elasticsearch_exporter:1.1.0
-          name: prometheus
-          command: ["--es.uri=http://localhost:9200", "--es.snapshots=true"]
-          ports:
-            - protocol: TCP
-              containerPort: 9114
-              name: prometheus
         - image: saidsef/elasticsearch
           name: elasticsearch
           ports:
@@ -64,18 +58,18 @@ spec:
               command:
                 - pgrep
                 - java
-            initialDelaySeconds: 3
+            initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               port: 9200
               path: _cat/health
-            initialDelaySeconds: 5
+            initialDelaySeconds: 30
             periodSeconds: 5
             successThreshold: 1
-            timeoutSeconds: 1
+            timeoutSeconds: 5
           # lifecycle:
           #   postStart:
           #     exec:
@@ -90,6 +84,41 @@ spec:
           volumeMounts:
             - name: elasticsearch-storage
               mountPath: /usr/share/elasticsearch/data
+        - image: justwatch/elasticsearch_exporter:1.1.0
+          name: prometheus
+          args:
+          - '--es.uri=http://localhost:9200'
+          - '--es.all'
+          - '--es.indices'
+          - '--es.snapshots'
+          ports:
+            - protocol: TCP
+              containerPort: 9114
+              name: prometheus
+          livenessProbe:
+            exec:
+              command:
+                - pgrep
+                - elasticsearch_exporter
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              port: 9114
+              path: /health
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "100m"
       volumes:
         - name: elasticsearch-storage
           hostPath:

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -23,11 +23,17 @@ spec:
         app: elasticsearch
     spec:
       # hostNetwork: true
-      tolerations:
-        - key: "kubernetes.io/arch"
-          value: "amd64"
-          operator: "Exists"
-          effect: "NoSchedule"
+      hostNetwork: true
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: "kubernetes.io/arch"
+                    operator: "In"
+                    values:
+                      - "amd64"
+              weight: 1
       initContainers:
         - name: volume-mount-fix
           image: busybox


### PR DESCRIPTION
In this PR we've:
 - 5aa0379  added prometheus container health checks
 - d2adf48 removed version env var
 - f3d94cb tag container by branch name and push to docker hub
 - 05f495b updated doc to reflect prometheus plugin removal
 - e8123b6 removed prometheus plugin install - this will now be handled by external service
 - d079122 added prometheus exporter container into the pod
 - bd9dc60 replaced tolerations with affinity
 - 20bad2a actually scan the current build
 - aef85b3 upgraded ES to v6.8.7