### PR TITLE
Upgrade es v6 8 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:6.8.12
+FROM elasticsearch:6.8.13
 
 LABEL maintainer="Said Sef <saidsef@gmail.com> (saidsef.co.uk)"
 

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -23,7 +23,6 @@ spec:
         name: elasticsearch
         app: elasticsearch
     spec:
-      # hostNetwork: true
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 60
       affinity:
@@ -82,10 +81,6 @@ spec:
             periodSeconds: 5
             successThreshold: 1
             timeoutSeconds: 5
-          # lifecycle:
-          #   postStart:
-          #     exec:
-          #       command: [""]
           resources:
             requests:
               memory: "2048Mi"


### PR DESCRIPTION
In this PR we've
 - upgraded elasticsearch to v6.8.13
 - removed un-used spec from deployment