### PR TITLE
Init container fix

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -1,10 +1,5 @@
 name: Tagging
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "deployment/*"
   workflow_run:
     workflows:
       - CI
@@ -12,6 +7,8 @@ on:
       - completed
     branch:
       - main
+    paths:
+      - "deployment/*"
   workflow_dispatch:
 
 env:

--- a/deployment/kustomization.yml
+++ b/deployment/kustomization.yml
@@ -11,7 +11,7 @@ images:
   newName: docker.io/saidsef/elasticsearch
   newTag: latest
 - name: prometheus
-  newName: quay.io/prometheuscommunity/elasticsearch-exporter:latest
+  newName: quay.io/prometheuscommunity/elasticsearch-exporter
   newTag: latest
 - name: busybox
   newName: docker.io/busybox

--- a/deployment/kustomization.yml
+++ b/deployment/kustomization.yml
@@ -13,3 +13,6 @@ images:
 - name: prometheus
   newName: quay.io/prometheuscommunity/elasticsearch-exporter:latest
   newTag: latest
+- name: busybox
+  newName: docker.io/busybox
+  newTag: stable

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -43,9 +43,10 @@ spec:
           volumeMounts:
             - name: elasticsearch-storage
               mountPath: /usr/share/elasticsearch/data
+              subPath: data
           securityContext:
-            allowPrivilegeEscalation: false
-            privileged: false
+            allowPrivilegeEscalation: true
+            privileged: true
             runAsGroup: 1000
             runAsUser: 1000
             capabilities:
@@ -53,7 +54,6 @@ spec:
                - ALL
              add:
                - CHOWN
-               - CHMOD
       containers:
         - image: docker.io/saidsef/elasticsearch:latest
           imagePullPolicy: Always
@@ -103,6 +103,7 @@ spec:
           volumeMounts:
             - name: elasticsearch-storage
               mountPath: /usr/share/elasticsearch/data
+              subPath: data
         - image: quay.io/prometheuscommunity/elasticsearch-exporter:latest
           imagePullPolicy: IfNotPresent
           name: prometheus

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -10,7 +10,6 @@ spec:
   serviceName: "elasticsearch"
   podManagementPolicy: "Parallel"
   revisionHistoryLimit: 1
-  replicas: 1
   selector:
     matchLabels:
       app: elasticsearch

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -101,6 +101,8 @@ spec:
           - '--es.indices'
           - '--es.snapshots'
           - '--es.shards'
+          - '--es.ssl-skip-verify'
+          - '--es.timeout=3s'
           ports:
             - protocol: TCP
               containerPort: 9114
@@ -124,7 +126,7 @@ spec:
             timeoutSeconds: 5
           resources:
             requests:
-              memory: "128Mi"
+              memory: "512Mi"
               cpu: "50m"
             limits:
               memory: "512Mi"

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -88,6 +88,7 @@ spec:
              add:
                - NET_BIND_SERVICE
                - SYS_TIME
+               - RLIMIT_NPROC
           volumeMounts:
             - name: elasticsearch-storage
               mountPath: /usr/share/elasticsearch/data

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -37,7 +37,7 @@ spec:
               weight: 1
       initContainers:
         - name: volume-mount-fix
-          image: busybox:1
+          image: docker.io/busybox:stable
           imagePullPolicy: Always
           command: ["sh", "-c", "chmod -R 777 /usr/share/elasticsearch/data"]
           volumeMounts:
@@ -53,6 +53,7 @@ spec:
                - ALL
              add:
                - CHOWN
+               - CHMOD
       containers:
         - image: docker.io/saidsef/elasticsearch:latest
           imagePullPolicy: Always
@@ -152,6 +153,4 @@ spec:
                - SYS_TIME
       volumes:
         - name: elasticsearch-storage
-          hostPath:
-            path: /mnt/es
-            type: DirectoryOrCreate
+          emptyDir: {}

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -9,6 +9,7 @@ metadata:
 spec:
   serviceName: "elasticsearch"
   podManagementPolicy: "Parallel"
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -39,7 +39,7 @@ spec:
         - name: volume-mount-fix
           image: docker.io/busybox:stable
           imagePullPolicy: Always
-          command: ["sh", "-c", "chmod -R 777 /usr/share/elasticsearch/data"]
+          command: ["sh", "-c", "/bin/chmod -R 777 /usr/share/elasticsearch/data"]
           volumeMounts:
             - name: elasticsearch-storage
               mountPath: /usr/share/elasticsearch/data

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -35,25 +35,6 @@ spec:
                     values:
                       - "amd64"
               weight: 1
-      initContainers:
-        - name: volume-mount-fix
-          image: docker.io/busybox:stable
-          imagePullPolicy: Always
-          command: ["sh", "-c", "/bin/chmod -R 777 /usr/share/elasticsearch/data"]
-          volumeMounts:
-            - name: elasticsearch-storage
-              mountPath: /usr/share/elasticsearch/data
-              subPath: data
-          securityContext:
-            allowPrivilegeEscalation: true
-            privileged: true
-            runAsGroup: 1000
-            runAsUser: 1000
-            capabilities:
-             drop:
-               - ALL
-             add:
-               - CHOWN
       containers:
         - image: docker.io/saidsef/elasticsearch:latest
           imagePullPolicy: Always
@@ -65,6 +46,13 @@ spec:
             - protocol: TCP
               containerPort: 9300
               name: cluster
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /usr/bin/curl
+                  - -XPOST
+                  - http://127.0.0.1:9200/_flush
           livenessProbe:
             exec:
               command:
@@ -108,7 +96,7 @@ spec:
           imagePullPolicy: IfNotPresent
           name: prometheus
           args:
-          - '--es.uri=http://localhost:9200'
+          - '--es.uri=http://127.0.0.1:9200'
           - '--es.all'
           - '--es.indices'
           - '--es.snapshots'

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -88,7 +88,6 @@ spec:
              add:
                - NET_BIND_SERVICE
                - SYS_TIME
-               - RLIMIT_NPROC
           volumeMounts:
             - name: elasticsearch-storage
               mountPath: /usr/share/elasticsearch/data


### PR DESCRIPTION
In this PR we've:
 - Removed init container
 - Fixed CI Tagging workflow
 - Moved to `emptyDir` storage in deployment