### PR TITLE
Upgraded ES to v6.8.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.19
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.20
 
 LABEL maintainer="Said Sef <saidsef@gmail.com> (saidsef.co.uk)"
 LABEL description="Elasticsearch with plugins"


### PR DESCRIPTION
Details: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/es-release-notes.html