### PR TITLE
chore(deployment): bump to v2026.06 and adopt app.kubernetes.io/* labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ A Prometheus metrics endpoint is exposed at `:9404/metrics` via the bundled [`jm
 
 The Kubernetes Service exposes port `9404` and the pod carries `prometheus.io/scrape` annotations for auto-discovery.
 
+## Upgrading
+
+The StatefulSet and Service selectors now use the standard `app.kubernetes.io/name: elasticsearch` label. `.spec.selector` is immutable on a StatefulSet, so existing clusters running the legacy `app: elasticsearch` selector must be recreated:
+
+```
+kubectl delete sts elasticsearch --cascade=orphan
+kubectl apply -k deployment/
+```
+
+`--cascade=orphan` keeps the running pods (and their `emptyDir` storage) in place while the StatefulSet object is replaced; the new StatefulSet adopts the existing pods on rollout.
+
 ## Installed Plugins list
 
 - repository-gcs

--- a/deployment/kustomization.yml
+++ b/deployment/kustomization.yml
@@ -9,8 +9,17 @@ resources:
 images:
 - name: elasticsearch
   newName: docker.io/saidsef/elasticsearch
-  newTag: v2023.01
+  newTag: v2026.06
 
-commonAnnotations:
-  app.kubernetes.io/name: elasticsearch
-  app.kubernetes.io/part-of: elasticsearch
+labels:
+- pairs:
+    app.kubernetes.io/name: elasticsearch
+  includeSelectors: true
+- pairs:
+    app.kubernetes.io/instance: elasticsearch
+    app.kubernetes.io/version: "6.8"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/part-of: elasticsearch
+    app.kubernetes.io/managed-by: kustomize
+  includeSelectors: false
+  includeTemplates: true

--- a/deployment/service.yml
+++ b/deployment/service.yml
@@ -3,13 +3,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: elasticsearch
-  labels:
-    name: elasticsearch
-    app: elasticsearch
 spec:
   type: ClusterIP
   selector:
-    app: elasticsearch
+    app.kubernetes.io/name: elasticsearch
   ports:
     - port: 9200
       protocol: TCP

--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -3,21 +3,15 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch
-  labels:
-    name: elasticsearch
-    app: elasticsearch
 spec:
   serviceName: "elasticsearch"
   podManagementPolicy: "Parallel"
   revisionHistoryLimit: 1
   selector:
     matchLabels:
-      app: elasticsearch
+      app.kubernetes.io/name: elasticsearch
   template:
     metadata:
-      labels:
-        name: elasticsearch
-        app: elasticsearch
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9404"
@@ -50,7 +44,7 @@ spec:
                       - "amd64"
               weight: 1
       containers:
-        - image: docker.io/saidsef/elasticsearch:v2023.12
+        - image: docker.io/saidsef/elasticsearch:v2026.06
           imagePullPolicy: Always
           name: elasticsearch
           ports:


### PR DESCRIPTION
## Summary

- Bump `kustomization.yml` and `statefulset.yml` image tag from `v2023.x` to `v2026.06` (missed from #133).
- Migrate legacy `app: elasticsearch` / `name: elasticsearch` labels to the full recommended `app.kubernetes.io/*` set (`name`, `instance`, `version`, `component`, `part-of`, `managed-by`).
- Apply centrally via kustomize `labels:` blocks: only `app.kubernetes.io/name` is scoped to selectors (selector-immutable-safe); the rest are pushed to top-level metadata and pod templates only.

## Why two label blocks?

`.spec.selector` on a StatefulSet is immutable. Scoping volatile labels (`version`, `managed-by`, etc.) out of selectors with `includeSelectors: false, includeTemplates: true` means future image/version bumps won't break `kubectl apply`.

## Upgrade impact

Existing clusters running the old `app: elasticsearch` selector must recreate the StatefulSet:

```
kubectl delete sts elasticsearch --cascade=orphan
kubectl apply -k deployment/
```

`--cascade=orphan` preserves the running pods during the swap. Documented in `README.md`.

## Test plan

- [x] `kubectl kustomize deployment/` renders all 6 labels on top-level metadata and pod template, with selectors containing only `app.kubernetes.io/name: elasticsearch`.
- [x] Image tag resolves to `docker.io/saidsef/elasticsearch:v2026.06`.
- [ ] `kube-test` CI workflow passes (kind cluster apply).
- [ ] `docker` build CI workflow passes.

Closes the loose end from #133.