### PR TITLE
fix(dockerfile): roll base back to elasticsearch 6.8.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docker.html
-FROM docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.8.23
 
 LABEL org.opencontainers.image.authors="Said Sef <saidsef@gmail.com> (saidsef.co.uk)"
 LABEL org.opencontainers.image.description="Elasticsearch 6.8 with plugins"


### PR DESCRIPTION
## Summary

- Revert the Dockerfile `FROM` from `docker.elastic.co/elasticsearch/elasticsearch:8.17.0` back to `6.8.23`.
- Fixes the JVM crash introduced when the JMX exporter from #133 was loaded on top of the accidental ES 8.17 base.

## Symptom

Container exits immediately on boot with:

```
Exception in thread "main" java.lang.reflect.InvocationTargetException
FATAL ERROR in native method: processing of -javaagent failed
Caused by: java.lang.NoClassDefFoundError: com/sun/net/httpserver/Authenticator
    at io.prometheus.jmx.JavaAgent.premain(JavaAgent.java:58)
Caused by: java.lang.ClassNotFoundException: com.sun.net.httpserver.Authenticator
```

## Root cause

- `jmx_prometheus_javaagent-0.20.0` uses `com.sun.net.httpserver.HttpServer` to expose `/metrics`. The `Authenticator` class lives in the `jdk.httpserver` JDK module.
- ES 8.x bundles a `jlink`-stripped JDK at `/usr/share/elasticsearch/jdk` that excludes `jdk.httpserver`. JVM init aborts before any application code runs.
- The base bump to 8.17.0 came from an automated dependabot PR (#95). It was never intentional - every other signal in the repo targets ES 6.8:
  - Dockerfile comment: `https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docker.html`
  - Labels: `Elasticsearch 6.8 with plugins`
  - Documentation URL points to 6.8 release notes
  - `xpack.monitoring.exporters.default_local.type=local` uses 6.8 syntax
  - The plugin install list (`mapper-annotated-text`, `mapper-murmur3`, etc.) is the 6.8 compatible set

ES 6.8.23 bundles a complete OpenJDK 13 distribution that includes `jdk.httpserver`, so the agent loads cleanly.

## Test plan

Local verification with the rebuilt image:

- [x] `docker build` succeeds against `6.8.23` base.
- [x] `GET :9200/` returns `"number":"6.8.23"`, cluster status green.
- [x] `GET :9200/_cat/plugins?v` lists all 9 installed plugins (`analysis-icu`, `analysis-phonetic`, `discovery-ec2`, `ingest-attachment`, `mapper-annotated-text`, `mapper-murmur3`, `mapper-size`, `repository-gcs`, `repository-s3`).
- [x] `GET :9404/metrics` returns HTTP 200, `text/plain; version=0.0.4`, ~75 KB body containing `jvm_*`, `jmx_*`, and `process_*` series. `jmx_scrape_error` is 0.
- [ ] CI `docker.yml` builds the image.
- [ ] `kube-test.yml` applies the manifest against a kind cluster.

## Follow-up

Consider an `ignore` rule in `.github/dependabot.yml` for `docker.elastic.co/elasticsearch/elasticsearch` major-version updates so future ES 7+ bumps require a manual decision.