### PR TITLE
fix(deployment): add startupProbe so liveness does not kill slow boots

### DIFF
--- a/deployment/statefulset.yml
+++ b/deployment/statefulset.yml
@@ -64,6 +64,13 @@ spec:
                   - /usr/bin/curl
                   - -XPOST
                   - http://127.0.0.1:9200/_flush
+          startupProbe:
+            tcpSocket:
+              port: 9200
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 30
+            timeoutSeconds: 5
           livenessProbe:
             tcpSocket:
               port: 9200


### PR DESCRIPTION
## Summary

Adds a `startupProbe` to the Elasticsearch StatefulSet so the existing liveness probe stops racing ES's first bind on `:9200`. Fixes the prod crashloop reported as:

```
[WARN][o.e.b.JNANatives] [ec2] Unable to lock JVM Memory: error=12, reason=Cannot allocate memory
...
[INFO][o.e.n.Node] [ec2] JVM arguments [...]
The container last terminated a minute ago with exit code 143 because of Error.
```

## Diagnosis (what is and isn't the cause)

Exit code 143 is SIGTERM, almost always sent by kubelet on liveness-probe failure. The memlock warning above is a red herring - `discovery.type=single-node` (baked into our Dockerfile ENV) makes ES treat the memlock check as a warning, not a fatal bootstrap failure. Reproduced this in a 6.8.23 container with `--ulimit memlock=8388608:8388608` (the exact value reported in your log): ES logs the same warning, then proceeds to `started` and goes green.

The actual cause is the liveness probe timing:

- Current config: `tcpSocket :9200`, `initialDelaySeconds: 30`, `failureThreshold: 3`, `periodSeconds: 10`. Total budget before SIGTERM: 60 seconds.
- ES 6.8.23 + the JMX agent + xpack.monitoring index creation binds 9200 around 45-55 seconds on a fresh pod.
- Verified in kind: the new startupProbe failed **three times** (at 20s, 30s, 40s) before ES bound 9200 at ~50s. The old liveness probe would have failed at exactly the same cadence (30s, 40s, 50s), and on a marginally slower prod node the 50s probe also fails - third failure trips `failureThreshold: 3`, kubelet sends SIGTERM, exit 143.

The diff between v2024.10 (works) and v2026.06 (fails) is PR #133 (JMX exporter). The exporter is correct - the `-javaagent` and the `-Djava.security.policy=...` (single `=` is the additive form per Oracle docs) both load fine. The agent just costs enough JVM-init time to push slow nodes past the 60s liveness budget.

## Fix

Standard K8s pattern: gate liveness behind a `startupProbe`.

```yaml
startupProbe:
  tcpSocket:
    port: 9200
  periodSeconds: 10
  successThreshold: 1
  failureThreshold: 30        # up to 5 minutes before liveness kicks in
  timeoutSeconds: 5
```

Once startup succeeds, `livenessProbe` and `readinessProbe` take over at their existing cadence. Fast nodes pass startup on the first probe - zero behaviour change there.

## Validation

Locally on a fresh kind cluster:

- `kubectl apply -k deployment/` -> pod Ready in 51s, Restart Count 0.
- `kubectl describe pod elasticsearch-0` shows the startupProbe correctly handling 3 transient failures while ES boots, then succeeding.
- `curl :9200/_cluster/health` -> green.
- `curl :9404/metrics` -> 200, full `java_lang_*` MBean series, `jmx_scrape_error 0`.

## Test plan

- [x] Local kind cluster + the manifest in this PR. Pod becomes Ready, cluster green, /metrics serving.
- [ ] CI `kube-test` workflow passes (auto-runs because `deployment/*` changed).
- [ ] Roll the merged image into your prod cluster - the crash loop should clear and Restart Count should stop climbing.

## What this PR does NOT do

- Does not touch the Dockerfile or the JMX exporter wiring (both correct as-is).
- Does not disable `bootstrap.memory_lock`. The warning is noisy but not the cause; that can be tidied separately if you want.
- Does not adjust liveness/readiness probes - they keep their existing behaviour once startup completes.